### PR TITLE
docs: add `https` protocol

### DIFF
--- a/tikzducks-doc.tex
+++ b/tikzducks-doc.tex
@@ -127,10 +127,10 @@
 \label{intro}
 
 Rubber ducks can be made of latex, but can they also be made with \LaTeX? Yes! The \tikzducks package is a \LaTeX{} package for rubber ducks to be used in \TikZ pictures. 
-This project is a continuation of \href{tex.stackexchange.com/a/347458/36296}{How can we draw a duck?}.
+This project is a continuation of \href{https://tex.stackexchange.com/a/347458/36296}{How can we draw a duck?}.
 
 This package is work in progress (and will probably never be really finished as there is an infinite amount of things which could be added), therefore I would be happy to hear your feedback and ideas how to improve the package. 
-The head version of the source code can be found on \url{github.com/samcarter/tikzducks}, including a bug tracker -- please make constructive use of it! A more stable package version can be found on \CTAN (\url{www.ctan.org/pkg/tikzducks}) and is included in both \miktex and \texlive as \tikzducks. If you seek any other assistance (not bug reports/feature requests), I suggest asking a question at \url{topanswers.xyz/tex}.
+The head version of the source code can be found on \url{https://github.com/samcarter/tikzducks}, including a bug tracker -- please make constructive use of it! A more stable package version can be found on \CTAN (\url{https://www.ctan.org/pkg/tikzducks}) and is included in both \miktex and \texlive as \tikzducks. If you seek any other assistance (not bug reports/feature requests), I suggest asking a question at \url{https://topanswers.xyz/tex}.
 
 \subsection{Acknowledgements}
 


### PR DESCRIPTION
When clicking, three out of four hyperlinks in the "Introduction" section will not jump to the expected webpage/URL. It seems a `http(s)` protocol is required by some PDF readers so I add the protocol.